### PR TITLE
WW-1666-modal-backdrop-click-trigger-unexpectedly-fires

### DIFF
--- a/src/wwSection.vue
+++ b/src/wwSection.vue
@@ -3,7 +3,7 @@
     class="modal-container"
     :style="backdropStyle"
     ww-responsive="modal-container"
-    @click.self="$emit('trigger-event', { name: 'backdropClick' })"
+    @mousedown.self="$emit('trigger-event', { name: 'backdropClick' })"
   >
     <transition :name="content.animation" mode="out-in">
       <wwLayout


### PR DESCRIPTION
J'ai hésite à faire 2 events différents mais en vrai le comportement que les gens vont vouloir par défaut c'est le mousedown et ils comprendront pas la diff sans aller lire dans la doc, donc je pense vaut mieux simplement remplacer l'event existant.